### PR TITLE
Feature: save if no inject

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { getDefaultFaviconConfig } from './faviconsDefaults.js';
 import { parseFragment } from 'parse5';
 import type { FaviconOptions } from './faviconsTypes.js';
+import * as fs from 'fs';
 
 type FaviconsConfig = Partial<FaviconOptions>
 export type ViteFaviconsPluginOptions = {
@@ -101,6 +102,12 @@ export const ViteFaviconsPlugin = (options: FaviconsPluginArgs = {} ): Plugin =>
 				acc[v.name] = resolvedValue;
 				return acc;
 			},<Record<string,string>>{})));
+		}
+		if (!lOptions.inject) {
+			const filePath = path.join(lOptions?.favicons?.path || '', 'webapp.html');
+			for (const tag of res.html) {
+				fs.writeFileSync(filePath, tag);
+			}
 		}
 	};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,9 +105,8 @@ export const ViteFaviconsPlugin = (options: FaviconsPluginArgs = {} ): Plugin =>
 		}
 		if (!lOptions.inject) {
 			const filePath = path.join(lOptions?.favicons?.path || '', 'webapp.html');
-			for (const tag of res.html) {
-				fs.writeFileSync(filePath, tag);
-			}
+			const output = res.html.join("\n");
+			fs.writeFileSync(filePath, output);
 		}
 	};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import path from 'path';
 import { getDefaultFaviconConfig } from './faviconsDefaults.js';
 import { parseFragment } from 'parse5';
 import type { FaviconOptions } from './faviconsTypes.js';
-import * as fs from 'fs';
 
 type FaviconsConfig = Partial<FaviconOptions>
 export type ViteFaviconsPluginOptions = {
@@ -104,9 +103,9 @@ export const ViteFaviconsPlugin = (options: FaviconsPluginArgs = {} ): Plugin =>
 			},<Record<string,string>>{})));
 		}
 		if (!lOptions.inject) {
-			const filePath = path.join(lOptions?.favicons?.path || '', 'webapp.html');
-			const output = res.html.join("\n");
-			fs.writeFileSync(filePath, output);
+			const name =  'webapp.html';
+			const contents = res.html.join("\n");
+			assetIds.set(name,ctx.emitFile({type:'asset',fileName: name,source:contents}));
 		}
 	};
 


### PR DESCRIPTION
If `inject` is set to `false`, this PR will cause it to emit the HTML result from `favicons` to `webapp.html`

This allows the `vite-plugin-favicon` to be used by a wider variety of setups such as Laravel, Ruby on Rails, etc. where something else controls the page rendering.