### PR TITLE
Fix incorrect module reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add the plugin to your vite config as follows:
 ```javascript
 const ViteFaviconsPlugin = require('vite-plugin-favicon')
 // or ESM
-import { ViteFaviconsPlugin } from "module";
+import { ViteFaviconsPlugin } from "vite-plugins-favicon";
 
 ...
 


### PR DESCRIPTION
Switch from `module` -> `vite-plugin-favicon`