### PR TITLE
fixes plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add the plugin to your vite config as follows:
 ```javascript
 const ViteFaviconsPlugin = require('vite-plugin-favicon')
 // or ESM
-import { ViteFaviconsPlugin } from "vite-plugins-favicon";
+import { ViteFaviconsPlugin } from "vite-plugin-favicon";
 
 ...
 


### PR DESCRIPTION
I was trying to use this example and noticed the include was for `vite-plugins-favicon` instead of `vite-plugin-favicon`